### PR TITLE
Minor updates to dynamically guess reserved memory

### DIFF
--- a/2.1/hdp-configuration-utils.py
+++ b/2.1/hdp-configuration-utils.py
@@ -61,7 +61,7 @@ def getReservedStackMemory(memory):
 def getReservedHBaseMem(memory):
   if (reservedHBase.has_key(memory)):
     return reservedHBase[memory]
-  if (memory <= 4):
+  if (memory <= 8):
     ret = 1
   elif (memory >= 512):
     ret = 64

--- a/2.1/hdp-configuration-utils.py
+++ b/2.1/hdp-configuration-utils.py
@@ -25,12 +25,12 @@ import math
 import ast
 
 ''' Reserved for OS + DN + NM,  Map: Memory => Reservation '''
-reservedStack = { 4:1, 7:2, 8:2, 16:2, 24:4, 48:6, 64:8, 72:8, 96:12, 
-                   128:24, 256:32, 512:64}
+reservedStack = {4:1, 16:2, 24:4, 48:6, 72:8, 96:12, 128:24, 256:32,
+                 512:64}
+
 ''' Reserved for HBase. Map: Memory => Reservation '''
-  
-reservedHBase = {4:1, 8:1, 16:2, 24:4, 48:8, 64:8, 72:8, 96:16, 
-                   128:24, 256:32, 512:64}
+reservedHBase = {8:1, 16:2, 24:4, 72:8, 96:16, 128:24, 256:32,
+                 512:64}
 GB = 1024
 
 def getMinContainerSize(memory):
@@ -42,7 +42,6 @@ def getMinContainerSize(memory):
     return 1024
   else:
     return 2048
-  pass
 
 def getReservedStackMemory(memory):
   if (reservedStack.has_key(memory)):
@@ -53,6 +52,10 @@ def getReservedStackMemory(memory):
     ret = 64
   else:
     ret = 1
+    for k in sorted(reservedStack.iterkeys()):
+      if (memory <= k):
+        ret = reservedStack[k]
+        break
   return ret
 
 def getReservedHBaseMem(memory):
@@ -64,6 +67,10 @@ def getReservedHBaseMem(memory):
     ret = 64
   else:
     ret = 2
+    for k in sorted(reservedHBase.iterkeys()):
+      if (memory <= k):
+        ret = reservedHBase[k]
+        break
   return ret
                     
 def getRoundedMemory(memory):
@@ -172,8 +179,6 @@ def main():
 
   hive_noconditional_task_size = int (getRoundedMemory(int(heap_size*0.33)) * 1024 * 1024)
   log.info("hive.auto.convert.join.noconditionaltask.size=" + str(hive_noconditional_task_size / 1000 * 1000))
-
-  pass
 
 if __name__ == '__main__':
   try:


### PR DESCRIPTION
I ran into a case where we used the script to automatically configure a system that had memory that didn't exist in the reservedStack dictionary (32GB), and that system ended up having way too little memory assigned to YARN. This pull request attempts to fix this issue by sorting the dictionary keys from smallest to largest, and finds the next largest key in the list and assigns the value from there.

I thought about assigning reserved memory for the first key that is smaller than the input memory, but I figured erring on the side of more memory reserved for OS, DN, and NM would be more desirable.